### PR TITLE
FMDatabaseQueue subclass using SpatialDatabase

### DIFF
--- a/SpatialDBKit.xcodeproj/project.pbxproj
+++ b/SpatialDBKit.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		CDC78F6D16EB488500965B41 /* Assets in Resources */ = {isa = PBXBuildFile; fileRef = CDC78F6C16EB488500965B41 /* Assets */; };
 		CDC78F6E16EB488500965B41 /* Assets in Resources */ = {isa = PBXBuildFile; fileRef = CDC78F6C16EB488500965B41 /* Assets */; };
 		CDFFB9CD179552AE0068ABA1 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CDFFB9CC179552AE0068ABA1 /* libz.dylib */; };
+		D192056A7DF25BB1BF4DAB27 /* SpatialDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = D192088C25D9248D06CBBD6C /* SpatialDatabaseQueue.m */; };
+		D1920951D0AFD2BE4CCCF169 /* SpatialDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = D192088C25D9248D06CBBD6C /* SpatialDatabaseQueue.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +68,8 @@
 		CDC3D30A16EDDDE400287FC4 /* FMResultSet+SpatialDBKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "FMResultSet+SpatialDBKit.m"; path = "SpatialDBKit/FMResultSet+SpatialDBKit.m"; sourceTree = "<group>"; };
 		CDC78F6C16EB488500965B41 /* Assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Assets; sourceTree = "<group>"; };
 		CDFFB9CC179552AE0068ABA1 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
+		D192088C25D9248D06CBBD6C /* SpatialDatabaseQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SpatialDatabaseQueue.m; path = SpatialDBKit/SpatialDatabaseQueue.m; sourceTree = "<group>"; };
+		D192091197599AF7D50934EA /* SpatialDatabaseQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpatialDatabaseQueue.h; path = SpatialDBKit/SpatialDatabaseQueue.h; sourceTree = "<group>"; };
 		E2E886BB35FA487DA9DC7FBE /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -146,6 +150,8 @@
 				CDC3D30216EDCD0900287FC4 /* SpatialDatabase.m */,
 				CDC3D30916EDDDE400287FC4 /* FMResultSet+SpatialDBKit.h */,
 				CDC3D30A16EDDDE400287FC4 /* FMResultSet+SpatialDBKit.m */,
+				D192091197599AF7D50934EA /* SpatialDatabaseQueue.h */,
+				D192088C25D9248D06CBBD6C /* SpatialDatabaseQueue.m */,
 			);
 			name = SpatialDBKit;
 			sourceTree = "<group>";
@@ -327,6 +333,7 @@
 			files = (
 				CD1CC89216EB3B35001CBC10 /* main.m in Sources */,
 				CD1CC89916EB3B35001CBC10 /* AppDelegate.m in Sources */,
+				D192056A7DF25BB1BF4DAB27 /* SpatialDatabaseQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +343,7 @@
 			files = (
 				CD1CC8A616EB3C87001CBC10 /* AppDelegate.m in Sources */,
 				CD1CC8AE16EB3C9C001CBC10 /* main.m in Sources */,
+				D1920951D0AFD2BE4CCCF169 /* SpatialDatabaseQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SpatialDBKit/SpatialDatabaseQueue.h
+++ b/SpatialDBKit/SpatialDatabaseQueue.h
@@ -1,0 +1,19 @@
+//
+//  SpatialDatabaseQueue.h
+//  SpatialDBKit
+//
+//  Created by James Gregory on 21/08/14.
+//
+// * This is free software; you can redistribute and/or modify it under
+// the terms of the Mozilla Public License Version 1.1
+//
+// Alternatively, the contents of this file may be used under the terms of
+// either the GNU General Public License Version 2 or later (the "GPL"), or
+// the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+// See the LICENSE file for more information.
+
+#import <Foundation/Foundation.h>
+#import <FMDB/FMDatabaseQueue.h>
+
+@interface SpatialDatabaseQueue : FMDatabaseQueue
+@end

--- a/SpatialDBKit/SpatialDatabaseQueue.m
+++ b/SpatialDBKit/SpatialDatabaseQueue.m
@@ -1,0 +1,25 @@
+//
+//  SpatialDatabaseQueue.m
+//  SpatialDBKit
+//
+//  Created by James Gregory on 21/08/14.
+//
+// * This is free software; you can redistribute and/or modify it under
+// the terms of the Mozilla Public License Version 1.1
+//
+// Alternatively, the contents of this file may be used under the terms of
+// either the GNU General Public License Version 2 or later (the "GPL"), or
+// the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+// See the LICENSE file for more information.
+
+#import "SpatialDatabaseQueue.h"
+#import "SpatialDatabase.h"
+
+@implementation SpatialDatabaseQueue
+
++ (Class)databaseClass
+{
+    return [SpatialDatabase class];
+}
+
+@end


### PR DESCRIPTION
Tiny subclass of `FMDatabaseQueue` to use `SpatialDatabase` when it creates a new database.
