### PR TITLE
Remove use of deprecated Spatialite functions

### DIFF
--- a/SpatialDBKit/SpatialDatabase.m
+++ b/SpatialDBKit/SpatialDatabase.m
@@ -40,7 +40,9 @@ void Swizzle(Class c, SEL orig, SEL new)
         method_exchangeImplementations(origMethod, newMethod);
 }
 
-@implementation SpatialDatabase
+@implementation SpatialDatabase {
+    void *spatialite_conn;
+}
 
 + (NSString*)spatialiteLibVersion
 {
@@ -56,12 +58,41 @@ void Swizzle(Class c, SEL orig, SEL new)
         SpatialDatabaseInstances++;
         if (SpatialDatabaseInstances==1)
         {
-            NSLog(@"Spatialite initialization");
-            spatialite_init(TRUE);
             Swizzle([FMResultSet class], @selector(objectForColumnIndex:), @selector(_swizzleObjectForColumnIndex:));
         }
     }
     return self;
+}
+
+- (BOOL)open
+{
+    BOOL opened = [super open];
+
+    if (opened)
+    {
+        [self initSpatialite];
+    }
+
+    return opened;
+}
+
+- (BOOL)openWithFlags:(int)flags
+{
+    BOOL opened = [super openWithFlags:flags];
+
+    if (opened)
+    {
+        [self initSpatialite];
+    }
+
+    return opened;
+}
+
+- (void)initSpatialite
+{
+    NSLog(@"Spatialite initialization");
+    spatialite_conn = spatialite_alloc_connection();
+    spatialite_init_ex(_db, spatialite_conn, 1);
 }
 
 -(void)dealloc
@@ -71,7 +102,7 @@ void Swizzle(Class c, SEL orig, SEL new)
     if (SpatialDatabaseInstances == 0)
     {
         NSLog(@"Terminating spatialite");
-        spatialite_cleanup();
+        spatialite_cleanup_ex(spatialite_conn);
     }
 }
 


### PR DESCRIPTION
Spatialite deprecated the use of `spatialite_init` in favour of `spatialite_init_ex` and equivalent functions for cleaning up. See [How to correctly initialize SQLite/SpatiaLite therad safe connections](https://groups.google.com/forum/#!searchin/spatialite-users/spatialite_init_ex/spatialite-users/83SOajOJ2JU/sgi5fuYAVVkJ) on the Spatialite Users list for more info.
